### PR TITLE
fix a deprecated error in numpy >=1.20

### DIFF
--- a/a_dcf/a_dcf.py
+++ b/a_dcf/a_dcf.py
@@ -23,7 +23,7 @@ def calculate_a_dcf(
     ):
 
     data = np.genfromtxt(sasv_score_dir, dtype=str, delimiter=" ")
-    scores = data[:, 2].astype(np.float)
+    scores = data[:, 2].astype(np.float64)
     keys = data[:, 3]
 
     # Extract target, nontarget, and spoof scores from the ASV scores


### PR DESCRIPTION
Since numpy 1.20, `np.float` is no longer usable. Of course, we can't simply use `float()` since `data[:, 2]` is an array and array comphrehension doesn't look pretty here ;)

Of course, you may specify the version in `setup.py` along with the package.